### PR TITLE
Removed application/json filter, as it does not work with my picker

### DIFF
--- a/app/src/main/java/org/fedorahosted/freeotp/MainActivity.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/MainActivity.java
@@ -226,7 +226,7 @@ public class MainActivity extends AppCompatActivity implements OnMenuItemClickLi
         // If one wanted to search for ogg vorbis files, the type would be "audio/ogg".
         // To search for all documents available via installed storage providers,
         // it would be "*/*".
-        intent.setType("application/json");
+        intent.setType("*/*");
 
         startActivityForResult(intent, READ_REQUEST_CODE);
     }


### PR DESCRIPTION
On my new Moto G5 Plus I was not able to import my backed up json file, as the "application/json" filter did not work for the .json file. I was not able to select the file in the picker.

This pull request removed the filter so I am able to select the file. (Code is tested on my Moto G5 Plus)