### PR TITLE
Fix bug unable to add a token after app crash

### DIFF
--- a/app/src/main/java/org/fedorahosted/freeotp/token/TokenPersistence.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/token/TokenPersistence.kt
@@ -129,7 +129,7 @@ class TokenPersistence @Inject constructor(private val ctx: Context) {
 
         // Shared preference may have key but delete in the order
         // The toke order is the source for tokens in the list
-        if (tokenOrder.any { it == key })
+        if (tokenOrder.any { it == key } && getToken(key) != null)
             return@withContext
 
         val order = tokenOrder.toMutableList()


### PR DESCRIPTION
Fix bug when token is in tokenOrder list but it's not actually saved …