### PR TITLE
Steam: default to 5-digit codes

### DIFF
--- a/app/src/main/java/org/fedorahosted/freeotp/token/Token.java
+++ b/app/src/main/java/org/fedorahosted/freeotp/token/Token.java
@@ -101,8 +101,12 @@ public class Token {
 
         try {
             String d = uri.getQueryParameter("digits");
-            if (d == null)
-                d = "6";
+            if (d == null) {
+                if (issuerExt.equals("Steam"))
+                    d = "5";
+                else
+                    d = "6";
+            }
             digits = Integer.parseInt(d);
             if (!issuerExt.equals("Steam") && digits != 6 && digits != 7 && digits != 8 && digits != 5)
                 throw new TokenUriInvalidException();


### PR DESCRIPTION
This is a needed workaround for Valve's API, which emits slightly-malformed TOTP URIs: omitting the `digits` parameter despite not using the [default value](https://github.com/google/google-authenticator/wiki/Key-Uri-Format#digits) of `6`. [Some](https://github.com/ValvePython/steamctl/blob/v0.7.0/steamctl/commands/authenticator/cmds.py#L383) QR-code generation libraries detect `otpauth://totp/Steam:…` and insert this parameter when necessary, but most do not.

This PR will bring this FreeOTP+'s behavior in line with other apps such as andOTP ([since Oct 2017](https://github.com/andOTP/andOTP/blob/v0.8.0/app/src/main/java/org/shadowice/flocke/andotp/Utilities/TokenCalculator.java#L37)), Kee Vault ([since Feb 2020](https://github.com/kee-org/keevault/blob/7804e5d4d028e683d0f27ee99cf6665d87f0f901/app/scripts/util/otp.js#L95)), and Aegis ([since last month](https://github.com/beemdevelopment/Aegis/blob/2c8a64f943d3f1407c382682912a3d7669c6fca8/app/src/main/java/com/beemdevelopment/aegis/otp/SteamInfo.java#L11)); it implements `5` as the default value for the `digits` field when `issuerExt` is `"Steam"`.