### PR TITLE
Pre-fetch custom icons to improve performance

### DIFF
--- a/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
@@ -56,6 +56,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
+import com.squareup.picasso.Picasso
 import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.main.*
 import org.fedorahosted.freeotp.R
@@ -352,6 +353,11 @@ class MainActivity : AppCompatActivity() {
             } else {
                 empty_view.visibility = View.GONE
                 token_list.visibility = View.VISIBLE
+                tokens.forEach {
+                    if (it.image != null) {
+                        Picasso.get().load(it.image).fetch()
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
@@ -345,6 +345,11 @@ class MainActivity : AppCompatActivity() {
                 }
             }
 
+            tokens.forEach {
+                if (it.image != null) {
+                    Picasso.get().load(it.image).fetch()
+                }
+            }
             tokenListAdapter.submitList(tokens)
 
             if (tokens.isEmpty()) {
@@ -353,11 +358,6 @@ class MainActivity : AppCompatActivity() {
             } else {
                 empty_view.visibility = View.GONE
                 token_list.visibility = View.VISIBLE
-                tokens.forEach {
-                    if (it.image != null) {
-                        Picasso.get().load(it.image).fetch()
-                    }
-                }
             }
         }
     }

--- a/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
@@ -56,11 +56,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
-import com.squareup.picasso.Picasso
 import dagger.android.AndroidInjection
 import kotlinx.android.synthetic.main.main.*
 import org.fedorahosted.freeotp.R
 import org.fedorahosted.freeotp.token.TokenPersistence
+import org.fedorahosted.freeotp.util.ImageUtil
 import org.fedorahosted.freeotp.util.ImportExportUtil
 import org.fedorahosted.freeotp.util.Settings
 import org.fedorahosted.freeotp.util.uiLifecycleScope
@@ -68,6 +68,7 @@ import javax.inject.Inject
 
 class MainActivity : AppCompatActivity() {
     @Inject lateinit var importFromUtil: ImportExportUtil
+    @Inject lateinit var imageUtil: ImageUtil
     @Inject lateinit var settings: Settings
     @Inject lateinit var tokenPersistence: TokenPersistence
 
@@ -345,11 +346,7 @@ class MainActivity : AppCompatActivity() {
                 }
             }
 
-            tokens.forEach {
-                if (it.image != null) {
-                    Picasso.get().load(it.image).fetch()
-                }
-            }
+            imageUtil.fetchImages(tokens)
             tokenListAdapter.submitList(tokens)
 
             if (tokens.isEmpty()) {

--- a/app/src/main/java/org/fedorahosted/freeotp/util/ImageUtil.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/util/ImageUtil.kt
@@ -2,12 +2,13 @@ package org.fedorahosted.freeotp.util
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.media.Image
 import android.net.Uri
 import android.provider.MediaStore
 import androidx.core.net.toUri
+import com.squareup.picasso.Picasso
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.fedorahosted.freeotp.token.Token
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -23,5 +24,13 @@ class ImageUtil @Inject constructor(val context: Context) {
         }
 
         outputFile.toUri()
+    }
+
+    suspend fun fetchImages(tokens: List<Token>) = withContext(Dispatchers.IO) {
+        tokens.forEach {
+            if (it.image != null) {
+                Picasso.get().load(it.image).fetch()
+            }
+        }
     }
 }

--- a/app/src/main/java/org/fedorahosted/freeotp/util/ImageUtil.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/util/ImageUtil.kt
@@ -13,6 +13,8 @@ import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private const val PREFETCHED_TOKEN_IMAGES = 12
+
 @Singleton
 class ImageUtil @Inject constructor(val context: Context) {
     suspend fun saveImageUriToFile(uri: Uri):Uri = withContext(Dispatchers.IO) {
@@ -27,7 +29,7 @@ class ImageUtil @Inject constructor(val context: Context) {
     }
 
     suspend fun fetchImages(tokens: List<Token>) = withContext(Dispatchers.IO) {
-        tokens.forEach {
+        tokens.subList(0, minOf(tokens.size, PREFETCHED_TOKEN_IMAGES)).forEach {
             if (it.image != null) {
                 Picasso.get().load(it.image).fetch()
             }


### PR DESCRIPTION
Pre-fetch custom token icons when refreshing tokens (e.g. during the creation of the main activity), improving icon load performance. Resolves issue https://github.com/helloworld1/FreeOTPPlus/issues/116 .