### PR TITLE
Lock when navigating away from MainActivity, and reduce Toasts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,8 @@
             android:name=".ui.MainActivity"
             android:clearTaskOnLaunch="true"
             android:label="@string/app_name"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:noHistory="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,8 +44,7 @@
             android:name=".ui.MainActivity"
             android:clearTaskOnLaunch="true"
             android:label="@string/app_name"
-            android:launchMode="singleTask"
-            android:noHistory="true">
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
@@ -75,6 +75,7 @@ class MainActivity : AppCompatActivity() {
     private var searchQuery = ""
     private var menu: Menu? = null
     private var lastSessionEndTimestamp = 0L;
+    private var openingChildActivity = false;
 
     private val tokenListObserver: AdapterDataObserver = object: AdapterDataObserver() {
         override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
@@ -146,6 +147,23 @@ class MainActivity : AppCompatActivity() {
     override fun onStop() {
         super.onStop()
         lastSessionEndTimestamp = System.currentTimeMillis()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        openingChildActivity = false
+    }
+
+    override fun onPause() {
+        super.onPause()
+        if (!openingChildActivity && !isFinishing) {
+            finish()
+        }
+    }
+
+    override fun startActivityForResult(intent: Intent?, requestCode: Int) {
+        openingChildActivity = true
+        super.startActivityForResult(intent, requestCode)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
@@ -385,9 +385,12 @@ class MainActivity : AppCompatActivity() {
                                                        errString: CharSequence) {
                         super.onAuthenticationError(errorCode, errString)
                         if (onFailure == null) {
-                            Toast.makeText(applicationContext,
-                                    "${getString(R.string.authentication_error)} $errString", Toast.LENGTH_SHORT)
-                                    .show()
+                            // Don't show error message toast if user pressed back button
+                            if (errorCode != BiometricPrompt.ERROR_USER_CANCELED) {
+                                Toast.makeText(applicationContext,
+                                        "${getString(R.string.authentication_error)} $errString", Toast.LENGTH_SHORT)
+                                        .show()
+                            }
 
                             if (errorCode != BiometricPrompt.ERROR_NO_DEVICE_CREDENTIAL) {
                                 finish()
@@ -400,21 +403,15 @@ class MainActivity : AppCompatActivity() {
                     override fun onAuthenticationSucceeded(
                             result: BiometricPrompt.AuthenticationResult) {
                         super.onAuthenticationSucceeded(result)
-                        Toast.makeText(applicationContext,
-                                getString(R.string.authentication_succeeded), Toast.LENGTH_SHORT)
-                                .show()
                         onSuccess()
                     }
 
                     override fun onAuthenticationFailed() {
+                        // Invalid authentication, e.g. wrong fingerprint. Android auth UI shows an
+                        // error, so no need for FreeOTP to show one
                         super.onAuthenticationFailed()
 
-                        if (onFailure == null) {
-                            Toast.makeText(applicationContext, getString(R.string.authentication_failed),
-                                    Toast.LENGTH_SHORT)
-                                    .show()
-                            finish()
-                        } else {
+                        if (onFailure != null) {
                             onFailure()
                         }
                     }

--- a/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
@@ -142,22 +142,15 @@ class MainActivity : AppCompatActivity() {
         } else {
             refreshTokenList("")
         }
+        openingChildActivity = false
     }
     
     override fun onStop() {
         super.onStop()
-        lastSessionEndTimestamp = System.currentTimeMillis()
-    }
-
-    override fun onResume() {
-        super.onResume()
-        openingChildActivity = false
-    }
-
-    override fun onPause() {
-        super.onPause()
-        if (!openingChildActivity && !isFinishing) {
-            finish()
+        if (openingChildActivity) {
+            lastSessionEndTimestamp = System.currentTimeMillis()
+        } else {
+            lastSessionEndTimestamp = 0L
         }
     }
 

--- a/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
@@ -75,7 +75,6 @@ class MainActivity : AppCompatActivity() {
     private var searchQuery = ""
     private var menu: Menu? = null
     private var lastSessionEndTimestamp = 0L;
-    private var openingChildActivity = false;
 
     private val tokenListObserver: AdapterDataObserver = object: AdapterDataObserver() {
         override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
@@ -142,21 +141,11 @@ class MainActivity : AppCompatActivity() {
         } else {
             refreshTokenList("")
         }
-        openingChildActivity = false
     }
     
     override fun onStop() {
         super.onStop()
-        if (openingChildActivity) {
-            lastSessionEndTimestamp = System.currentTimeMillis()
-        } else {
-            lastSessionEndTimestamp = 0L
-        }
-    }
-
-    override fun startActivityForResult(intent: Intent?, requestCode: Int) {
-        openingChildActivity = true
-        super.startActivityForResult(intent, requestCode)
+        lastSessionEndTimestamp = System.currentTimeMillis()
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {


### PR DESCRIPTION
Change MainActivity to not have a history, which will result in Authentication occurring whenever navigating away and navigating back (if auth is enabled). Also removed some of the more verbose Toast messages.