### PR TITLE
Refresh token list when auth enabled

### DIFF
--- a/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/ui/MainActivity.kt
@@ -210,6 +210,7 @@ class MainActivity : AppCompatActivity() {
                     verifyAuthentication(onSuccess =  {
                         settings.requireAuthentication = true
                         refreshOptionMenu()
+                        refreshTokenList("")
                     }, onFailure = {
                         Toast.makeText(applicationContext,
                                 R.string.unable_to_authenticate, Toast.LENGTH_SHORT)


### PR DESCRIPTION
Fixes a regression where enabling authentication causes an empty token list to be displayed