### PR TITLE
Add function to show qr code of token

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,9 @@
             android:name=".ui.EditActivity"
             android:windowSoftInputMode="adjustResize" />
         <activity
+            android:name=".ui.ShowQRCodeActivity"
+            android:windowSoftInputMode="adjustResize" />
+        <activity
             android:name=".ui.MainActivity"
             android:clearTaskOnLaunch="true"
             android:label="@string/app_name"

--- a/app/src/main/java/org/fedorahosted/freeotp/ui/ShowQRCodeActivity.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/ui/ShowQRCodeActivity.kt
@@ -1,0 +1,103 @@
+/*
+ * FreeOTP
+ *
+ * Authors: Nathaniel McCallum <npmccallum@redhat.com>
+ *
+ * Copyright (C) 2014  Nathaniel McCallum, Red Hat
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fedorahosted.freeotp.ui
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.Button
+import android.widget.EditText
+import android.widget.ImageButton
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.qrcode.QRCodeWriter
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import org.fedorahosted.freeotp.R
+import org.fedorahosted.freeotp.data.OtpTokenDatabase
+import org.fedorahosted.freeotp.data.OtpTokenFactory
+import org.fedorahosted.freeotp.databinding.EditBinding
+import org.fedorahosted.freeotp.databinding.ShowQrcodeBinding
+import org.fedorahosted.freeotp.util.ImageUtil
+import org.fedorahosted.freeotp.util.setTokenImage
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class ShowQRCodeActivity : AppCompatActivity() {
+
+    @Inject lateinit var otpTokenDatabase: OtpTokenDatabase
+    @Inject lateinit var imageUtil: ImageUtil
+
+    private lateinit var binding: ShowQrcodeBinding
+    private lateinit var mIssuer: TextView
+    private lateinit var mLabel: TextView
+
+    private var tokenId: Long = 0L
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        binding = ShowQrcodeBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        lifecycleScope.launch {
+            tokenId = intent.getLongExtra(EXTRA_TOKEN_ID, 0)
+
+            // Get token values.
+            val token = otpTokenDatabase.otpTokenDao().get(tokenId).first() ?: return@launch
+
+            // Get references to widgets.
+            mIssuer = findViewById<View>(R.id.issuer) as TextView
+            mLabel = findViewById<View>(R.id.label) as TextView
+            setSupportActionBar(findViewById(R.id.toolbar))
+
+            mLabel.setText(token.label)
+            mIssuer.setText(token.issuer)
+            binding.imageView.setTokenImage(token)
+            Log.d("TEST", OtpTokenFactory.toUri(token).toString());
+
+            val qrcodeWriter = QRCodeWriter();
+            var qrcodeSize = 400
+            var encoded = qrcodeWriter.encode(OtpTokenFactory.toUri(token).toString(), BarcodeFormat.QR_CODE, qrcodeSize, qrcodeSize);
+            var pixels = IntArray(qrcodeSize*qrcodeSize)
+            for (x in 0..(qrcodeSize-1)) {
+                for (y in 0..(qrcodeSize-1)) {
+                    if (encoded.get(x, y)) {
+                        pixels[x*qrcodeSize+y] = Color.BLACK;
+                    } else {
+                        pixels[x*qrcodeSize+y] = Color.WHITE;
+                    }
+                }
+            }
+            var qrcode = Bitmap.createBitmap(pixels, qrcodeSize, qrcodeSize, Bitmap.Config.RGB_565);
+            binding.qrcode.setImageBitmap(qrcode);
+        }
+    }
+
+    companion object {
+        const val EXTRA_TOKEN_ID = "token_id"
+    }
+}

--- a/app/src/main/java/org/fedorahosted/freeotp/ui/SquareRelativeLayout.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/ui/SquareRelativeLayout.kt
@@ -1,0 +1,15 @@
+package org.fedorahosted.freeotp.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.RelativeLayout
+
+class SquareRelativeLayout @JvmOverloads constructor(
+        context: Context, attrs: AttributeSet? = null
+) : RelativeLayout(context, attrs) {
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, widthMeasureSpec)
+    }
+
+}

--- a/app/src/main/java/org/fedorahosted/freeotp/ui/TokenViewHolder.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/ui/TokenViewHolder.kt
@@ -27,6 +27,12 @@ class TokenViewHolder(private val activity: Activity,
                 i.putExtra(DeleteActivity.EXTRA_TOKEN_ID, token.id)
                 activity.startActivity(i)
             }
+
+            R.id.action_show_qrcode -> {
+                val i = Intent(tokenLayout.context, ShowQRCodeActivity::class.java)
+                i.putExtra(EditActivity.EXTRA_TOKEN_ID, token.id)
+                activity.startActivity(i)
+            }
         }
         true
     }

--- a/app/src/main/res/layout/show_qrcode.xml
+++ b/app/src/main/res/layout/show_qrcode.xml
@@ -1,0 +1,52 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_weight="0"
+        android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/image_view"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:scaleType="fitCenter"
+            android:src="@drawable/logo" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:layout_marginLeft="8dp"
+            android:orientation="vertical">
+
+            <include layout="@layout/titles" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <org.fedorahosted.freeotp.ui.SquareRelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/qrcode"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:srcCompat="@drawable/qrcode" />
+    </org.fedorahosted.freeotp.ui.SquareRelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/menu/token.xml
+++ b/app/src/main/res/menu/token.xml
@@ -30,4 +30,10 @@
         android:icon="@android:drawable/ic_menu_delete"
         android:title="@string/delete"
         />
+
+    <item
+        android:id="@+id/action_show_qrcode"
+        android:icon="@android:drawable/ic_menu_delete"
+        android:title="@string/show_qrcode"
+        />
 </menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -4,6 +4,7 @@
     <string name="invalid_token">Der angegebene Token ist ungültig!</string>
     <string name="delete">Löschen</string>
     <string name="edit">Bearbeiten</string>
+    <string name="show_qrcode">Zeige QR-Code</string>
     <string name="restore_defaults">Standards wiederherstellen</string>
     <string name="no_keys">Keine OTP-Schlüssel installiert.</string>
     <string name="add_token">Token hinzufügen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="invalid_token">The token specified was invalid!</string>
     <string name="delete">Delete</string>
     <string name="edit">Edit</string>
+    <string name="show_qrcode">Show QR-Code</string>
     <string name="restore_defaults">Restore Defaults</string>
     <string name="no_keys">No OTP keys installed.</string>
     <string name="add_token">Add Token</string>


### PR DESCRIPTION
A new menu option to display the QR code of a token so that it can be scanned by another person.

![main](https://user-images.githubusercontent.com/1745726/155603274-02b836a4-6534-44cb-a8fc-b602123c17a1.png)
![qrcode](https://user-images.githubusercontent.com/1745726/155603295-51a74ded-a53e-42a1-96a6-19e2acd17534.png)

