### PR TITLE
[Fix] tokenList rearrangement by dragging

### DIFF
--- a/app/src/main/java/org/fedorahosted/freeotp/ui/TokenTouchCallback.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/ui/TokenTouchCallback.kt
@@ -7,6 +7,7 @@ import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.launch
 import org.fedorahosted.freeotp.data.OtpTokenDatabase
 import java.util.*
+import java.util.concurrent.CopyOnWriteArrayList
 
 class TokenTouchCallback(private val lifecycleOwner: LifecycleOwner,
                          private val adapter: TokenListAdapter,
@@ -17,7 +18,16 @@ class TokenTouchCallback(private val lifecycleOwner: LifecycleOwner,
         or ItemTouchHelper.RIGHT, 0) {
 
     // List of all Token movements during drag (pair.first = sourceToken.id, pair.second = targetToken.id)
-    private val movePairs: MutableList<Pair<Long,Long>> = mutableListOf()
+    private val movePairs: MutableList<Pair<Long,Long>> = CopyOnWriteArrayList(mutableListOf())
+
+
+    override fun onSelectedChanged(viewHolder: RecyclerView.ViewHolder?, actionState: Int) {
+        super.onSelectedChanged(viewHolder, actionState)
+        // Clear movePairs when drag starts
+        if(actionState ==  ItemTouchHelper.ACTION_STATE_DRAG){
+            movePairs.clear()
+        }
+    }
 
     override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
 
@@ -42,7 +52,6 @@ class TokenTouchCallback(private val lifecycleOwner: LifecycleOwner,
     override fun clearView(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder) {
         lifecycleOwner.lifecycleScope.launch {
             optTokenDatabase.otpTokenDao().movePairs(movePairs)
-            movePairs.clear()
         }
         super.clearView(recyclerView, viewHolder)
     }

--- a/app/src/main/java/org/fedorahosted/freeotp/ui/TokenTouchCallback.kt
+++ b/app/src/main/java/org/fedorahosted/freeotp/ui/TokenTouchCallback.kt
@@ -1,13 +1,12 @@
 package org.fedorahosted.freeotp.ui
 
-import android.os.Handler
-import android.os.Looper
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
 import kotlinx.coroutines.launch
 import org.fedorahosted.freeotp.data.OtpTokenDatabase
+import java.util.*
 
 class TokenTouchCallback(private val lifecycleOwner: LifecycleOwner,
                          private val adapter: TokenListAdapter,
@@ -17,31 +16,38 @@ class TokenTouchCallback(private val lifecycleOwner: LifecycleOwner,
         or ItemTouchHelper.LEFT
         or ItemTouchHelper.RIGHT, 0) {
 
-    private var moveRunnable: Runnable? = null
-
-    private val handler = Handler(Looper.getMainLooper())
+    // List of all Token movements during drag (pair.first = sourceToken.id, pair.second = targetToken.id)
+    private val movePairs: MutableList<Pair<Long,Long>> = mutableListOf()
 
     override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
-        moveRunnable?.let {
-            handler.removeCallbacks(it)
-        }
 
-        moveRunnable = Runnable {
-            lifecycleOwner.lifecycleScope.launch {
-                val sourceToken = adapter.currentList[viewHolder.adapterPosition] ?: return@launch
-                val targetToken = adapter.currentList[target.adapterPosition] ?: return@launch
-                optTokenDatabase.otpTokenDao().move(sourceToken.id, targetToken.id)
-            }
-        }
+        lifecycleOwner.lifecycleScope.launch {
+           val sourceToken = adapter.currentList[viewHolder.adapterPosition] ?: return@launch
+           val targetToken = adapter.currentList[target.adapterPosition] ?: return@launch
 
-        moveRunnable?.let {
-            handler.postDelayed(it, 150)
+            // Swap source and target token and update the view
+           val rearrangedList = ArrayList(adapter.currentList)
+           Collections.swap(rearrangedList, viewHolder.adapterPosition, target.adapterPosition)
+           adapter.submitList(rearrangedList)
+            // Keep track of all token moves
+           movePairs.add(Pair(sourceToken.id, targetToken.id))
         }
 
         return true
     }
 
+    /**
+     * Is called after finishing or cancelling a drag/swipe (only called once per drag)
+     */
+    override fun clearView(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder) {
+        lifecycleOwner.lifecycleScope.launch {
+            optTokenDatabase.otpTokenDao().movePairs(movePairs)
+            movePairs.clear()
+        }
+        super.clearView(recyclerView, viewHolder)
+    }
 
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
     }
+
 }

--- a/token-data/src/main/java/org/fedorahosted/freeotp/data/OtpTokenDao.kt
+++ b/token-data/src/main/java/org/fedorahosted/freeotp/data/OtpTokenDao.kt
@@ -56,17 +56,18 @@ interface OtpTokenDao {
     suspend fun incrementCounterRaw(query: SupportSQLiteQuery): Int
 
     @Transaction
-    suspend fun move(tokenId1: Long, tokenId2: Long) {
-        withContext(Dispatchers.IO) {
-            val token1 = get(tokenId1).first()
-            val token2 = get(tokenId2).first()
+    suspend fun movePairs(pairs : List<Pair<Long,Long>>){
+        for(pair in pairs) {
+            withContext(Dispatchers.IO) {
+                val token1 = get(pair.first).first()
+                val token2 = get(pair.second).first()
 
-            if (token1 == null || token2 == null) {
-                return@withContext
+                if (token1 == null || token2 == null) {
+                    return@withContext
+                }
+                updateOrdinal(pair.first, token2.ordinal)
+                updateOrdinal(pair.second, token1.ordinal)
             }
-
-            updateOrdinal(tokenId1, token2.ordinal)
-            updateOrdinal(tokenId2, token1.ordinal)
         }
     }
 }

--- a/token-data/src/main/java/org/fedorahosted/freeotp/data/OtpTokenDao.kt
+++ b/token-data/src/main/java/org/fedorahosted/freeotp/data/OtpTokenDao.kt
@@ -57,7 +57,7 @@ interface OtpTokenDao {
 
     @Transaction
     suspend fun movePairs(pairs : List<Pair<Long,Long>>){
-        for(pair in pairs) {
+        for(pair in pairs.listIterator()) {
             withContext(Dispatchers.IO) {
                 val token1 = get(pair.first).first()
                 val token2 = get(pair.second).first()


### PR DESCRIPTION
fixes #185 

With this commit, instead of comiting every movement of a token during a drag to the DB, a List of token-moves are stored during a drag. Once a drag action is finished the `clearView` method is called (see [ItemTouchHelper.Callback#clearView](https://developer.android.com/reference/androidx/recyclerview/widget/ItemTouchHelper.Callback#clearView(androidx.recyclerview.widget.RecyclerView,%20androidx.recyclerview.widget.RecyclerView.ViewHolder))). In this method all tracked token-moves are comitted in 1 transaction to the DB.
Also the delay of the moveRunnable was removed, which leads to a fluent execution of the drag action.



![fix-rearrange-token](https://user-images.githubusercontent.com/39240633/178549641-de5498d6-2608-4017-975c-67cbee3d73e5.gif)

