### PR TITLE
Json import overwrites token if it already exists

### DIFF
--- a/token-data/src/main/java/org/fedorahosted/freeotp/data/MigrationUtil.kt
+++ b/token-data/src/main/java/org/fedorahosted/freeotp/data/MigrationUtil.kt
@@ -15,7 +15,7 @@ class MigrationUtil @Inject constructor(
 
     suspend fun migrate() {
         withContext(Dispatchers.IO) {
-            val tokenList = convertLegacyTokensToOtpTokens(tokenPersistence.getTokens())
+            val tokenList = convertLegacyTokensToOtpTokens(tokenPersistence.getTokens(), true)
             optTokenDatabase.otpTokenDao().insertAll(tokenList)
             tokenPersistence.setLegacyTokenMigrated()
         }
@@ -30,13 +30,13 @@ class MigrationUtil @Inject constructor(
             tokenMap[tokenKey]
         }
 
-        convertLegacyTokensToOtpTokens(legacyTokens)
+        convertLegacyTokensToOtpTokens(legacyTokens, false)
     }
 
-    suspend fun convertLegacyTokensToOtpTokens(legacyTokens: List<Token>): List<OtpToken> = withContext(Dispatchers.IO) {
+    suspend fun convertLegacyTokensToOtpTokens(legacyTokens: List<Token>, idAsIndex: Boolean): List<OtpToken> = withContext(Dispatchers.IO) {
         legacyTokens.mapIndexed{ index, legacyToken ->
             OtpToken(
-                id = index.toLong() + 1,
+                id = if (idAsIndex) index.toLong() + 1 else 0,
                 ordinal = index.toLong() + 1,
                 issuer = legacyToken.issuer,
                 label = legacyToken.label,

--- a/token-data/src/main/java/org/fedorahosted/freeotp/data/OtpTokenDao.kt
+++ b/token-data/src/main/java/org/fedorahosted/freeotp/data/OtpTokenDao.kt
@@ -23,6 +23,9 @@ interface OtpTokenDao {
     @Query("select * from otp_tokens where id = :id")
     fun get(id: Long): Flow<OtpToken?>
 
+    @Query("select * from otp_tokens where issuer = :issuer and label = :label and LOWER(secret) = LOWER(:secret)")
+    fun getByIssuerAndLabelAndSecret(issuer: String?, label: String, secret: String): Flow<OtpToken?>
+
     @Query("select ordinal from otp_tokens order by ordinal desc limit 1")
     fun getLastOrdinal(): Long?
 


### PR DESCRIPTION
Proposition to fix #207 
When importing from JSON, for every token from the JSON it will be checked if the token already exists (check for equality of `issuer`, `label` and `secret`). If the token already exists, only overwrite the token, else insert a new token.
Also the `id` of imported tokens should not be set to their index in the JSON, but should be generated.

If this proposition is supposed to be how the JSON Import should work, the displayed message `import_json_file_warning`:
```
All the current tokens will be cleared and overwritten after importing.
```
is misleading.  The current tokens are not cleared, existing tokens might only get overwritten. If an existing token is not present in the JSON file it will not be cleared/deleted.
Therefore I propose to change the text to e.g.:
```
The current tokens might be overwritten after importing.
```